### PR TITLE
Session Locator | Isolation Levels not respected in Sites.config

### DIFF
--- a/src/Orchard.Web/Config/Sites.config
+++ b/src/Orchard.Web/Config/Sites.config
@@ -26,8 +26,8 @@
             -->
             <!--
             <component instance-scope="per-lifetime-scope"
-                       type="Orchard.Data.SessionLocator, Orchard.Framework"
-                       service="Orchard.Data.ISessionLocator">
+                       type="Orchard.Data.TransactionManager, Orchard.Framework"
+                       service="Orchard.Data.ITransactionManager">
                 <properties>
                     <property name="IsolationLevel" value="ReadUncommitted" />
                 </properties>


### PR DESCRIPTION
IsolationLevel was refactored out of the SessionLocator class into TransactionManager, and the Sites.config was not updated to reflect this change.